### PR TITLE
#104 ヘッダー修正

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -29,6 +29,7 @@ header {
 	/* 要素の重なり順序指定 */
 	position: fixed;
 	top: 0;
+	height: 95px;
 	width: 100%;
 }
 header h1 {

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -5,16 +5,29 @@
         <h1><%= link_to "探求学園Rails専攻", root_path, class: "nav-link navbar-brand" %></h1>
       </div>
       <div>
-        <ul>
-          <p>〇〇 ××さん</p>
-        </ul>
-        <ul class="navbar-nav">
-          <a class="nav-link text-dark" href="#">商品検索</a>
-          <a class="nav-link text-dark" href="#">カート</a>
-          <a class="nav-link text-dark" href="#">注文履歴</a>
-          <a class="nav-link text-dark" href="#">ユーザ情報</a>
-          <%= link_to "ログアウト", logout_path, method: :delete, class: "nav-link text-dark" %>
-        </ul>
+        <% if logged_in? %>
+          <ul>
+            <p> <%= current_user.last_name %>
+            <%= current_user.first_name %>さん</p>
+          </ul>
+          <ul class="navbar-nav">
+            <%= link_to '商品検索', products_path, class: "nav-link text-dark" %>
+            <%# TODO: カート機能実装後にそちらに遷移させる%>
+            <a class="nav-link text-dark" href="#">カート</a>
+            <%# TODO: 注文履歴実装後そちらに遷移させる%>
+            <a class="nav-link text-dark" href="#">注文履歴</a>
+            <%= link_to 'ユーザ情報', current_user, class: "nav-link text-dark" %>
+            <%= link_to "ログアウト", logout_path, method: :delete, class: "nav-link text-dark" %>
+          </ul>
+        <% else %>
+          <ul>
+            <li>
+              <%= link_to 'ログイン', login_path, class: "text-dark" %>
+              <%# TODO: TODO: 新規登録ページができたらそちらに遷移させる%>
+              <a class="text-dark" href="#"> 新規登録 </a>
+            </li>
+          </ul>
+        <% end %>
       </div>
     </div>
   </nav>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,48 +1,29 @@
 <% provide(:title, "ログイン画面") %>
-  <%# TODO: ログイン機能を実装したときにヘッダー部分をテンプレート化する%>
-  <header>
-    <nav class="navbar navbar-expand-lg navbar-light">
-      <div class="container-fluid">
-        <div class="navbar-nav mr-auto">
-          <h1><a class="nav-link navbar-brand" href="#">探求学園Rails専攻</a></h1>
-        </div>
-        <div>
-          <ul>
-            <li>
-              <a class="text-dark" href="#"> ログイン </a>
-              <a class="text-dark" href="#"> 新規登録 </a>
-            </li>
-          </ul>
-        </div>
+<main>
+  <h4 class="d-flex justify-content-center mt-5 mb-3">ログイン画面</h4>
+  <%= form_with scope: :session, url: login_path, local: true do |f| %>
+    <div class="d-flex justify-content-center">
+      <div class="">
+        <%= f.label :email, "メールアドレス", class: "mb-0" %>
+        <p><%= f.email_field :email, id: "email" %></p>
       </div>
-    </nav>
-  </header>
-
-  <main>
-    <h4 class="d-flex justify-content-center mt-5 mb-3">ログイン画面</h4>
-    <%= form_with scope: :session, url: login_path, local: true do |f| %>
-      <div class="d-flex justify-content-center">
-        <div class="">
-          <%= f.label :email, "メールアドレス", class: "mb-0" %>
-          <p><%= f.email_field :email, id: "email" %></p>
-        </div>
-      </div>
-
-      <div class="d-flex justify-content-center">
-        <div>
-          <%= f.label :password, "パスワード", class: "mb-0" %>
-          <p><%= f.password_field :password, id: "password" %></p>
-        </div>
-      </div>
-
-      <div class="d-flex justify-content-center">
-        <div>
-          <%= f.submit "ログイン", class: "btn btn-primary" %>
-        </div>
-      </div>
-    <% end %>
+    </div>
 
     <div class="d-flex justify-content-center">
-      <a href="">まだ登録がお済みでない方はこちら</a>
+      <div>
+        <%= f.label :password, "パスワード", class: "mb-0" %>
+        <p><%= f.password_field :password, id: "password" %></p>
+      </div>
     </div>
-  </main>
+
+    <div class="d-flex justify-content-center">
+      <div>
+        <%= f.submit "ログイン", class: "btn btn-primary" %>
+      </div>
+    </div>
+  <% end %>
+
+  <div class="d-flex justify-content-center">
+    <a href="">まだ登録がお済みでない方はこちら</a>
+  </div>
+</main>


### PR DESCRIPTION
## このプルリクエストで何をしたのか
・ログイン/ログアウトで表示の切り替え
　ログイン中についてはユーザ名表示
・リンクがあるものは遷移させる
・sessionsのnew.html.erbのヘッダー共通化/インデント修正

## 対象issue
https://github.com/quest-academia/qa-rails-ec-training-cactus/issues/30

## 重点的に見てほしいところ(不安なところ)

## 実装できなくて後回しにしたところ

## チェックリスト
- [x] 動作確認は実行した?

## その他参考情報
●ログイン前
<img width="1224" alt="image" src="https://user-images.githubusercontent.com/101488503/178131125-9fd59144-de16-4e03-9f96-5cf9a4086e8a.png">


●ログイン後
<img width="1224" alt="image" src="https://user-images.githubusercontent.com/101488503/178131141-797670ab-bf9e-446f-8b61-afad1f1fa79b.png">


