### PR TITLE
#105 ユーザ登録ページ

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,6 +21,22 @@ class UsersController < ApplicationController
     end
   end
 
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+    @user.user_classification_id = 1
+    if @user.save
+      flash[:success] = 'ユーザーを登録しました。こちらからログインしてください。'
+      redirect_to login_path
+    else
+      flash.now[:danger] = '登録に失敗しました。'
+      render "new"
+    end
+  end
+
   def user_params
     params.require(:user).permit(:last_name, :first_name, :zipcode, :prefecture, :municipality, :address, :apartments, :email, :phone_number, :company_name, :password, :password_confirmation)
   end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -23,8 +23,7 @@
           <ul>
             <li>
               <%= link_to 'ログイン', login_path, class: "text-dark" %>
-              <%# TODO: TODO: 新規登録ページができたらそちらに遷移させる%>
-              <a class="text-dark" href="#"> 新規登録 </a>
+              <%= link_to '新規登録', signup_path, class: "text-dark" %>
             </li>
           </ul>
         <% end %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -24,6 +24,6 @@
   <% end %>
 
   <div class="d-flex justify-content-center">
-    <a href="">まだ登録がお済みでない方はこちら</a>
+    <%= link_to 'まだ登録がお済みでない方はこちら', signup_path %>
   </div>
 </main>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,5 @@
+<% if object.errors.any? %>
+  <% object.errors.full_messages.each do |message| %>
+    <div class="alert alert-danger"><%= message %></div>
+  <% end %>
+<% end %>

--- a/app/views/shared/_user_error_messages.html.erb
+++ b/app/views/shared/_user_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if @user.errors.full_messages.any? %>
+  <div class="alert alert-danger">
+    <ul>
+      <% @user.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/shared/_user_error_messages.html.erb
+++ b/app/views/shared/_user_error_messages.html.erb
@@ -1,9 +1,0 @@
-<% if @user.errors.full_messages.any? %>
-  <div class="alert alert-danger">
-    <ul>
-      <% @user.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-    </ul>
-  </div>
-<% end %>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -13,7 +13,7 @@
           まだアカウントを<br>
           お持ちでない方はこちら
         </p>
-        <a class="btn btn-primary" href="#" role="button">新規登録</a>
+        <%= link_to '新規登録', signup_path, class: "btn btn-primary" %>
       </div>
       <div class="mt-3 ml-3 text-center col-sm-3">
         <p>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -5,7 +5,7 @@
   <div class="row mb-5 ml-5">
     <div class="col-sm-6 offset-sm-3">
       <%= form_with(model: @user, local: true, url: signup_path) do |f| %>
-        <%= render 'shared/user_error_messages' %>
+        <%= render 'shared/error_messages', object: f.object %>
         <div>
           <p>氏名</p>
           <div class="row ms-2">

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,3 +1,4 @@
+<% provide(:title, "ユーザー登録") %>
 <div class="container">
   <div class="jumbotron text-center bg-white mt-5">
     <h2>お客様情報登録</h2>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,0 +1,96 @@
+<div class="container">
+  <div class="jumbotron text-center bg-white mt-5">
+    <h2>お客様情報登録</h2>
+  </div>
+  <div class="row mb-5 ml-5">
+    <div class="col-sm-6 offset-sm-3">
+      <%= form_with(model: @user, local: true, url: signup_path) do |f| %>
+        <%= render 'shared/user_error_messages' %>
+        <div>
+          <p>氏名</p>
+          <div class="row ms-2">
+            <%= f.label :last_name, "姓", {class: "col-sm"} %>
+            <div class="col-sm-5">
+              <%= f.text_field :last_name, class:'form-control' %>
+            </div>
+            <%= f.label :first_name, "名", {class: "col-sm"} %>
+            <div class="col-sm-5">
+              <%= f.text_field :first_name, class:'form-control' %>
+            </div>
+          </div>
+          <div>
+            <%= f.label :zipcode, "郵便番号" %>
+            <div class="col-sm-6 ms-4">
+              <%= f.text_field :zipcode, class:'form-control' %>
+            </div>
+          </div>
+          <div>
+            <p class="mb-1">住所</p>
+            <div class="ms-4">
+              <div class="row">
+                <%= f.label :prefecture, "都道府県", {class: "mt-2 ml-4 col-sm"} %>
+                <div class="col-sm-9 mt-1">
+                  <%= f.text_field :prefecture, class:'form-control' %>
+                </div>
+              </div>
+
+              <div class="row">
+                <%= f.label :municipality, "市区町村", {class: "mt-2 ml-4 col-sm"} %>
+                <div class="col-sm-9 mt-1">
+                  <%= f.text_field :municipality, class:'form-control' %>
+                </div>
+              </div>
+              <div class="row">
+                <%= f.label :address, "番地", {class: "mt-2 ml-4 col-sm"} %>
+                <div class="col-sm-9 ml-4 mt-1">
+                  <%= f.text_field :address, class:'form-control' %>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div>
+            <%= f.label :apartments, "マンション・部屋番号", {class: "ml-2 ms-4"} %>
+            <div class="offset-sm-1">
+              <div class="ml-5 mr-5">
+                <%= f.text_field :apartments, class:'form-control' %>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div>
+          <%= f.label :email, "メールアドレス" %>
+          <div class="ml-3 mr-5 ms-4">
+            <%= f.text_field :email, class:'form-control' %>
+          </div>
+        </div>
+        <div>
+          <%= f.label :phone_number, "電話番号" %>
+          <div class="ml-3 mr-5 ms-4">
+            <%= f.text_field :phone_number, class:'form-control' %>
+          </div>
+        </div>
+        <div>
+          <%= f.label :password, "パスワード" %>
+          <div class="col-sm-8 ms-4">
+            <%= f.password_field :password, class:'form-control' %>
+          </div>
+        </div>
+        <div>
+          <%= f.label :password_confirmation, "パスワード再入力" %>
+          <div class="col-sm-8 ms-4">
+            <%= f.password_field :password_confirmation, class:'form-control' %>
+          </div>
+        </div>
+        <div class="row justify-content-center">
+          <div class="col-sm-2 mt-5">
+            <%= f.submit "登録", class: "btn btn-primary btn-block" %>
+
+          </div>
+        </div>
+      <% end %>
+      <div class="mt-5 text-center">
+        <h3><%= link_to 'ログインはこちらから', login_path %></h3>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/locales/models/user.yml
+++ b/config/locales/models/user.yml
@@ -7,6 +7,7 @@ ja:
         last_name: 姓
         first_name: 名
         password: パスワード
+        password_confirmation: パスワード再入力
         zipcode: 住所
         prefecture: 都道府県
         municipality: 市区町村

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   resources :users
   resources :products
+  get '/signup', to: 'users#new'
+  post '/signup', to: 'users#create'
   get '/login', to: 'sessions#new'
   post '/login', to: 'sessions#create'
   delete '/logout', to: 'sessions#destroy'


### PR DESCRIPTION
## このプルリクエストで何をしたのか
・ユーザ登録ページ作成/登録処理実装
・routesにパス指定
・新規登録ページ作成へのリンク指定

プルリク後に1点修正
・エラーメッセージを日本語に修正（password_confirmation）
https://github.com/thimon21/railsthimon/pull/8/commits/5e4d0b684494d35ed7a123aafefc529fe5c92be2

## 対象issue
https://github.com/quest-academia/qa-rails-ec-training-cactus/issues/29

## 重点的に見てほしいところ(不安なところ)

## 実装できなくて後回しにしたところ

## チェックリスト
- [x] 動作確認は実行した?

## その他参考情報
●登録失敗時
<img width="1264" alt="image" src="https://user-images.githubusercontent.com/101488503/178732125-7afd800f-9c09-47ba-804d-4ad98e7a3ada.png">

●登録成功時
<img width="1267" alt="image" src="https://user-images.githubusercontent.com/101488503/178729701-5d34729e-baa8-4ad0-8110-afd61ffa0209.png">

