### PR TITLE
#106 ユーザー退会処理

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :logged_in_user, only: [:show, :edit, :update]
+  before_action :logged_in_user, only: [:show, :edit, :update, :destroy]
   before_action :correct_user, only: [:show, :edit, :update]
   include SessionsHelper
   def show
@@ -35,6 +35,11 @@ class UsersController < ApplicationController
       flash.now[:danger] = '登録に失敗しました。'
       render "new"
     end
+  end
+
+  def destroy
+    User.find_by(id: params[:id]).destroy!
+    redirect_to root_path
   end
 
   def user_params

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -4,7 +4,7 @@
       <h2 class="text-center mt-5">ユーザ情報修正</h2>
       <div>
         <%= form_with(model: @user, local: true) do |f| %>
-          <table width="50%" style="margin-left:350px">       
+          <table width="50%" style="margin-left:350px">
             <tr height="40">
               <td align="center">
                 氏名<span style="float: right">
@@ -68,7 +68,7 @@
                 <%= f.label :address, "メールアドレス" %>
               </td>
               <td colspan="2">
-                <%= f.email_field :email %> 
+                <%= f.email_field :email %>
               </td>
             </tr>
 
@@ -77,16 +77,16 @@
                 <%= f.label :phone_number, "電話番号" %>
               </td>
               <td colspan="2">
-                <%= f.text_field :phone_number %> 
+                <%= f.text_field :phone_number %>
               </td>
             </tr>
-          
+
             <tr height="40">
               <td align="center">
                 <%= f.label :password, "パスワード" %>
               </td>
               <td colspan="2">
-                <%= f.password_field :password %> 
+                <%= f.password_field :password %>
               </td>
             </tr>
 
@@ -95,23 +95,23 @@
               <%= f.label :password_confirmation, "パスワード(再入力)" %>
               </td>
               <td colspan="2">
-              <%= f.password_field :password_confirmation %> 
+              <%= f.password_field :password_confirmation %>
               </td>
             </tr>
           </table>
 
           <div class="row mt-5">
             <div class="col-5">
-              <div class="d-flex justify-content-end">  
+              <div class="d-flex justify-content-end">
                 <%= f.submit "修正", class: "btn btn-primary" %>
               </div>
             </div>
-        
+
             <div class="col-5 offset-2">
-              <button class="btn btn-danger" type="submit">退会</button>
+              <%= link_to "退会", @user, method: :delete, data: { confirm: "ユーザーデータが全て削除されます。本当に退会しますか？" }, class: "btn btn-danger" %>
             </div>
           </div>
         <% end %>
-      </div>  
-           
+      </div>
+
     </main>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -108,7 +108,7 @@
             </div>
 
             <div class="col-5 offset-2">
-              <%= link_to "退会", @user, method: :delete, data: { confirm: "ユーザーデータが全て削除されます。本当に退会しますか？" }, class: "btn btn-danger" %>
+              <%= link_to "退会", @user, method: :delete, data: { confirm: "このユーザーに関するデータが全て削除されます。本当に退会しますか？" }, class: "btn btn-danger" %>
             </div>
           </div>
         <% end %>


### PR DESCRIPTION
## このプルリクエストで何をしたのか
・destroyアクション定義
・処理完了後、トップページ遷移（自動的にログアウト/退会ユーザ情報無し確認済）
・ログインユーザーのみ退会できるよう追記
・退会前にダイアログボックス表示

## 対象issue
https://github.com/quest-academia/qa-rails-ec-training-cactus/issues/31

## 重点的に見てほしいところ(不安なところ)

## 実装できなくて後回しにしたところ

## チェックリスト
- [ ] 動作確認は実行した?

## その他参考情
●ダイアログボックス表示
<img width="1174" alt="image" src="https://user-images.githubusercontent.com/101488503/179116281-65f01f6c-cc4b-4b5c-88a9-450300c467db.png">

●退会処理後遷移
<img width="1178" alt="image" src="https://user-images.githubusercontent.com/101488503/179116385-d67e81fd-12b9-48c3-9542-5412f535bc39.png">
